### PR TITLE
refactor: use {dir}/index.html layout

### DIFF
--- a/assets/partials/_top-links.hbs
+++ b/assets/partials/_top-links.hbs
@@ -1,0 +1,6 @@
+<span class="top-links"></span>
+    <a class="top-link" href="{{config.base_url}}">All TILs</a>
+    {{#each config.top_links}}
+    <a class="top-link" href="{{this.url}}">{{this.title}}</a>
+    {{/each}}
+</span>

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -79,3 +79,7 @@ blockquote {
     margin: 1.5em 10px;
     padding: 0.5em 10px;
 }
+
+.top-link {
+    margin-right: 2em;
+}

--- a/assets/templates/category.hbs
+++ b/assets/templates/category.hbs
@@ -9,7 +9,7 @@
         {{/if}}
     </head>
     <body>
-        <a href="{{config.base_url}}">Index</a>
+        {{> _top-links}}
 
         <h1>TILs for {{tag}}</h1>
 

--- a/assets/templates/index.hbs
+++ b/assets/templates/index.hbs
@@ -11,6 +11,8 @@
         {{/if}}
     </head>
     <body>
+        {{> _top-links}}
+
         <h1>TILs</h1>
 
         {{#if index_fragment}}

--- a/assets/templates/til.hbs
+++ b/assets/templates/til.hbs
@@ -10,7 +10,7 @@
         {{/if}}
     </head>
     <body>
-        <a href="{{config.base_url}}">Index</a>
+        {{> _top-links}}
 
         <header class="til-header">
             <h1 class="til-title">{{meta.title}}</h1>

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,4 +4,12 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct Config {
     pub(crate) base_url: String,
     pub(crate) mastodon: Option<String>,
+    #[serde(default)]
+    pub(crate) top_links: Vec<Link>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct Link {
+    title: String,
+    url: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,11 @@ struct Args {
     /// Defaults to $CWD/site.
     #[arg(short, long)]
     outdir: Option<PathBuf>,
+
+    /// Generates in 'dev' mode, meaning suitable for use with a local
+    /// development HTTP server.
+    #[arg(long)]
+    dev: bool,
 }
 
 fn main() -> Result<()> {
@@ -46,9 +51,13 @@ fn main() -> Result<()> {
             .with_context(|| "could not load config file")?,
     )?;
 
-    // All URL joining assumes a terminating `/`.
-    if !config.base_url.ends_with('/') {
-        config.base_url.push('/');
+    if args.dev {
+        config.base_url = "/".into();
+    } else {
+        // All URL joining assumes a terminating `/`.
+        if !config.base_url.ends_with('/') {
+            config.base_url.push('/');
+        }
     }
 
     let outdir = match args.outdir {


### PR DESCRIPTION
This moves from `post/{post}.html` to `post/{post}/index.html`, which more webservers understand by default for graceful redirects.

It also adds the `top_links` config item, which allows a user to specify one or more URLs to display at the top of every page (next to the backlink for the TIL index).

Finally, it adds the `--dev` flag, which ignores any `base_url` setting and always renders at `/`, which makes its output drop-in compatible with just about any local HTTP dev server (like `python -m http.server`).